### PR TITLE
Fix initial scroll for some browsers

### DIFF
--- a/p/scripts/main.js
+++ b/p/scripts/main.js
@@ -2028,6 +2028,7 @@ function init_normal() {
 }
 
 function init_main_beforeDOM() {
+	history.scrollRestoration = 'manual';
 	document.scrollingElement.scrollTop = 0;
 	init_shortcuts();
 	if (['normal', 'reader', 'global'].indexOf(context.current_view) >= 0) {


### PR DESCRIPTION
Changes proposed in this pull request:

For some browsers (I tested desktop Edge and mobile Safari), setting document.scrollingElement.scrollTop to zero does not seem to be enough to reset the scroll position at start. Setting history.scrollRestoration = 'manual' seems to fix it for these browsers. Firefox seems to work without this fix but works also with it.

How to test the feature manually:

1. Open FreshRSS and scroll down some feed that has entries
2. Press the reload button in the browser
3. Verify that scroll position is reset to beginning of the feed and that no unexpected entries were marked as read if read-on-scroll is enabled in FreshRSS config.

Pull request checklist:

- [X] clear commit messages
- [X] code manually tested
- [X] unit tests written (optional if too hard)
- [X] documentation updated

[Additional information can be found in the documentation](https://github.com/FreshRSS/FreshRSS/tree/edge/docs/en/developers/04_Pull_requests.md).
